### PR TITLE
Replaced the deprecated share function for singleton method

### DIFF
--- a/src/Offline/Settings/SettingsServiceProvider.php
+++ b/src/Offline/Settings/SettingsServiceProvider.php
@@ -37,8 +37,7 @@ class SettingsServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(
             __DIR__ . '/../../config/config.php', 'settings'
         );
-        $this->app['settings'] = $this->app->share(function ($app) {
-
+        $this->app->singleton('settings', function ($app) {
             $config = $app->config->get('settings', [
                 'cache_file' => storage_path('settings.json'),
                 'db_table'   => 'settings'


### PR DESCRIPTION
Replaced the deprecated share function for singleton method. The share function is deprecated for Laravel 5.4 so the package is not compatible with Laravel 5.4. With this change the package is compatible with the latest version of Laravel.